### PR TITLE
Avoid calling wrong cursor executable.

### DIFF
--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -32,6 +32,13 @@ export default function registerEditCommand(program: Command, stax: Stax) {
       }
 
       const hex = Buffer.from(JSON.stringify({ containerName: app.primary.containerName })).toString('hex')
-      run(`${editor} --folder-uri=vscode-remote://attached-container+${hex}%${app.primary.config.workspace}`)
+      const folderUri = `vscode-remote://attached-container+${hex}%${app.primary.config.workspace}`
+
+      // On macOS, use 'open -a' for Cursor to avoid picking up the remote CLI binary
+      if (process.platform === 'darwin' && editor === 'cursor') {
+        run(`open -a Cursor --args --folder-uri=${folderUri}`)
+      } else {
+        run(`${editor} --folder-uri=${folderUri}`)
+      }
     })
 }


### PR DESCRIPTION
Seems the wrong executable is being run and crashing.  I believe the crash info is something else since that continues to happen but the cursor app now opens for the container.

```
[alexstupka@20291-Alex-Stupka]$ stax edit notes
▶️  docker container exec --interactive --tty stax-notes-web sh -c 'pkill --echo --full "[c]ursor-server" || true'
sh killed (pid 8937)
node killed (pid 8947)
node killed (pid 9211)
sh killed (pid 9466)
java killed (pid 9467)
▶️  cursor --folder-uri=vscode-remote://attached-container+7b22636f6e7461696e65724e616d65223a22737461782d6e6f7465732d776562227d%/workspaces/notes
[1212/082940.867322:FATAL:electron/shell/app/electron_main_delegate_mac.mm:65] Unable to find helper app
[1212/082940.870305:WARNING:third_party/crashpad/crashpad/util/process/process_memory_mac.cc:94] mach_vm_read(0x16ce90000, 0x8000): (os/kern) invalid address (1)
[1212/082940.873964:FATAL:electron/shell/app/electron_main_delegate_mac.mm:65] Unable to find helper app
[1212/082941.094410:WARNING:third_party/crashpad/crashpad/snapshot/mac/mach_o_image_annotations_reader.cc:92] unexpected crash info version 7 in /System/Library/Frameworks/IOSurface.framework/Versions/A/IOSurface

```

<img width="831" height="564" alt="CleanShot 2025-12-12 at 09 26 28" src="https://github.com/user-attachments/assets/77fafff7-bd12-44b1-aaf5-29ae574e593e" />
